### PR TITLE
expected output for xpath_context input data

### DIFF
--- a/its2.0/expected/xpath_context/html/xpath_context1htmloutput.txt
+++ b/its2.0/expected/xpath_context/html/xpath_context1htmloutput.txt
@@ -1,0 +1,14 @@
+/html
+/html/head[1]
+/html/head[1]/script[1]
+/html/head[1]/script[1]/@type
+/html/head[1]/meta[1]
+/html/head[1]/meta[1]/@charset
+/html/head[1]/title[1]
+/html/body[1]
+/html/body[1]/p[1]  idValue="par_1_of_3"
+/html/body[1]/p[1]/@title
+/html/body[1]/p[1]  idValue="par_2_of_3"
+/html/body[1]/p[1]/@title
+/html/body[1]/p[1]  idValue="par_3_of_3"
+/html/body[1]/p[1]/@title

--- a/its2.0/expected/xpath_context/xml/xpath_context1xmloutput.txt
+++ b/its2.0/expected/xpath_context/xml/xpath_context1xmloutput.txt
@@ -1,0 +1,12 @@
+/resource
+/resource/its:rules[1]
+/resource/its:rules[1]/@version
+/resource/its:rules[1]/its:idValueRule[1]
+/resource/its:rules[1]/its:idValueRule[1]/@idValue
+/resource/its:rules[1]/its:idValueRule[1]/@selector
+/resource/par[1]	idValue="par_1_of_3"
+/resource/par[1]/@title
+/resource/par[2]	idValue="par_2_of_3"
+/resource/par[2]/@title
+/resource/par[3]	idValue="par_3_of_3"
+/resource/par[3]/@title


### PR DESCRIPTION
This is the expected data for the input data added in
w3c/its-2.0-testsuite-inputdata#5. The purpose of the test is to check
that position and size are set for the XPath contexts of relative
selectors. This is done using `idValue`, which is an XPath that returns
a string, making the test simpler. XPath functions `pos()` and `last()`
are evaluated and concatenated in the `idValue` values.

See also
http://lists.w3.org/Archives/Public/public-i18n-its-ig/2013Jul/0037.html.
